### PR TITLE
Add frontend hook tests

### DIFF
--- a/frontend/src/hooks/catalog/useExercisesCatalog.test.tsx
+++ b/frontend/src/hooks/catalog/useExercisesCatalog.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useExercisesCatalog } from './useExercisesCatalog';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useExercisesCatalog', () => {
+  const url = 'http://localhost:3000/api/v1/exercises-catalog?custom=true';
+  it('fetches catalog', async () => {
+    const data = [{ exerciseId: 1, name: 'Bench', primaryMuscle: 'Chest', default: true, templateExercises: [], workoutExercises: [] }];
+    server.use(http.get(url, () => HttpResponse.json(data)));
+    const { result } = renderHook(() => useExercisesCatalog(true), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(data);
+  });
+});

--- a/frontend/src/hooks/catalog/useFilteredExercise.test.tsx
+++ b/frontend/src/hooks/catalog/useFilteredExercise.test.tsx
@@ -1,0 +1,24 @@
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useFilteredExercises } from './useFilteredExercise';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useFilteredExercises', () => {
+  const url = 'http://localhost:3000/api/v1/exercises-catalog?custom=true';
+  it('filters returned list', async () => {
+    const data = [
+      { exerciseId: 1, name: 'Bench', primaryMuscle: 'Chest', default: true, templateExercises: [], workoutExercises: [] },
+      { exerciseId: 2, name: 'Squat', primaryMuscle: 'Legs', default: true, templateExercises: [], workoutExercises: [] },
+    ];
+    server.use(http.get(url, () => HttpResponse.json(data)));
+    const { result } = renderHook(() => useFilteredExercises('ben'), { wrapper });
+    await result.waitForNextUpdate?.();
+    expect(result.current.filtered).toEqual([data[0]]);
+  });
+});

--- a/frontend/src/hooks/templateExercises/useCreateTemplateExercise.test.tsx
+++ b/frontend/src/hooks/templateExercises/useCreateTemplateExercise.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useCreateTemplateExercise } from './useCreateTemplateExercise';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useCreateTemplateExercise', () => {
+  const url = 'http://localhost:3000/api/v1/template-workouts/abc/exercises';
+  it('creates exercise', async () => {
+    const created = { templateExerciseId: '1', exerciseId: 2, position: 1, sets: [] };
+    server.use(http.post(url, () => HttpResponse.json(created)));
+    const { result } = renderHook(() => useCreateTemplateExercise(), { wrapper });
+    await act(() => result.current.mutateAsync({ workoutId: 'abc', dto: { exerciseId: 2, position: 1 } }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(created);
+  });
+});

--- a/frontend/src/hooks/templateExercises/useDeleteTemplateExercise.test.tsx
+++ b/frontend/src/hooks/templateExercises/useDeleteTemplateExercise.test.tsx
@@ -1,0 +1,20 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useDeleteTemplateExercise } from './useDeleteTemplateExercise';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useDeleteTemplateExercise', () => {
+  const url = 'http://localhost:3000/api/v1/template-workouts/abc/exercises/1';
+  it('deletes exercise', async () => {
+    server.use(http.delete(url, () => HttpResponse.json({})));
+    const { result } = renderHook(() => useDeleteTemplateExercise(), { wrapper });
+    await act(() => result.current.mutateAsync({ workoutId: 'abc', id: '1' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/frontend/src/hooks/templateExercises/useTemplateExercises.test.tsx
+++ b/frontend/src/hooks/templateExercises/useTemplateExercises.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useTemplateExercises } from './useTemplateExercises';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useTemplateExercises', () => {
+  const url = 'http://localhost:3000/api/v1/template-workouts/abc/exercises';
+  it('returns exercises', async () => {
+    const data = [{ templateExerciseId: '1', exerciseId: 2, position: 1, sets: [] }];
+    server.use(http.get(url, () => HttpResponse.json(data)));
+    const { result } = renderHook(() => useTemplateExercises('abc'), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(data);
+  });
+});

--- a/frontend/src/hooks/templateExercises/useUpdateTemplateExercise.test.tsx
+++ b/frontend/src/hooks/templateExercises/useUpdateTemplateExercise.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useUpdateTemplateExercise } from './useUpdateTemplateExercise';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useUpdateTemplateExercise', () => {
+  const url = 'http://localhost:3000/api/v1/template-workouts/abc/exercises/1';
+  it('updates exercise', async () => {
+    const updated = { templateExerciseId: '1', exerciseId: 2, position: 2, sets: [] };
+    server.use(http.patch(url, () => HttpResponse.json(updated)));
+    const { result } = renderHook(() => useUpdateTemplateExercise(), { wrapper });
+    await act(() => result.current.mutateAsync({ workoutId: 'abc', id: '1', dto: { position: 2 } }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(updated);
+  });
+});

--- a/frontend/src/hooks/templateSets/useCreateTemplateSet.test.tsx
+++ b/frontend/src/hooks/templateSets/useCreateTemplateSet.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useCreateTemplateSet } from './useCreateTemplateSet';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useCreateTemplateSet', () => {
+  const url = 'http://localhost:3000/api/v1/template-workouts/abc/exercises/def/sets';
+  it('creates set', async () => {
+    const created = { id: 's1', reps: 1, weight: 1, position: 1 };
+    server.use(http.post(url, () => HttpResponse.json(created)));
+    const { result } = renderHook(() => useCreateTemplateSet(), { wrapper });
+    await act(() => result.current.mutateAsync({ workoutId: 'abc', exerciseId: 'def', dto: { reps: 1, weight: 1, position: 1 } }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(created);
+  });
+});

--- a/frontend/src/hooks/templateSets/useDeleteTemplateSet.test.tsx
+++ b/frontend/src/hooks/templateSets/useDeleteTemplateSet.test.tsx
@@ -1,0 +1,20 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http } from 'msw';
+import { server } from '../../mocks/server';
+import { useDeleteTemplateSet } from './useDeleteTemplateSet';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useDeleteTemplateSet', () => {
+  const url = 'http://localhost:3000/api/v1/template-workouts/abc/exercises/def/sets/1';
+  it('deletes set', async () => {
+    server.use(http.delete(url, () => HttpResponse.json({})));
+    const { result } = renderHook(() => useDeleteTemplateSet(), { wrapper });
+    await act(() => result.current.mutateAsync({ workoutId: 'abc', exerciseId: 'def', setId: '1' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/frontend/src/hooks/templateSets/useTemplateSets.test.tsx
+++ b/frontend/src/hooks/templateSets/useTemplateSets.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useTemplateSets } from './useTemplateSets';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useTemplateSets', () => {
+  const url = 'http://localhost:3000/api/v1/template-workouts/abc/exercises/def/sets';
+  it('returns sets', async () => {
+    const data = [{ id: 's1', reps: 1, weight: 1, position: 1 }];
+    server.use(http.get(url, () => HttpResponse.json(data)));
+    const { result } = renderHook(() => useTemplateSets('abc', 'def'), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(data);
+  });
+});

--- a/frontend/src/hooks/templateSets/useUpdateTemplateSet.test.tsx
+++ b/frontend/src/hooks/templateSets/useUpdateTemplateSet.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useUpdateTemplateSet } from './useUpdateTemplateSet';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useUpdateTemplateSet', () => {
+  const url = 'http://localhost:3000/api/v1/template-workouts/abc/exercises/def/sets/1';
+  it('updates set', async () => {
+    const updated = { id: '1', reps: 2, weight: 2, position: 1 };
+    server.use(http.patch(url, () => HttpResponse.json(updated)));
+    const { result } = renderHook(() => useUpdateTemplateSet(), { wrapper });
+    await act(() => result.current.mutateAsync({ workoutId: 'abc', exerciseId: 'def', setId: '1', dto: { reps: 2 } }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(updated);
+  });
+});

--- a/frontend/src/hooks/templateWorkouts/useCreateGlobalTemplateWorkout.test.tsx
+++ b/frontend/src/hooks/templateWorkouts/useCreateGlobalTemplateWorkout.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useCreateGlobalTemplateWorkout } from './useCreateGlobalTemplateWorkout';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useCreateGlobalTemplateWorkout', () => {
+  const url = 'http://localhost:3000/api/v1/template-workouts/global';
+  it('creates workout', async () => {
+    const workout = { id: '1', name: 'tmp', createdAt: '', updatedAt: '' };
+    server.use(http.post(url, () => HttpResponse.json(workout)));
+    const { result } = renderHook(() => useCreateGlobalTemplateWorkout(), { wrapper });
+    await act(() => result.current.mutateAsync({ dto: { name: 'tmp' } }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(workout);
+  });
+});

--- a/frontend/src/hooks/templateWorkouts/useCreateTemplateWorkout.test.tsx
+++ b/frontend/src/hooks/templateWorkouts/useCreateTemplateWorkout.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useCreateTemplateWorkout } from './useCreateTemplateWorkout';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useCreateTemplateWorkout', () => {
+  const url = 'http://localhost:3000/api/v1/template-workouts';
+  it('creates workout', async () => {
+    const workout = { id: '1', name: 'tmp', createdAt: '', updatedAt: '' };
+    server.use(http.post(url, () => HttpResponse.json(workout)));
+    const { result } = renderHook(() => useCreateTemplateWorkout(), { wrapper });
+    await act(() => result.current.mutateAsync({ dto: { name: 'tmp' } }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(workout);
+  });
+});

--- a/frontend/src/hooks/templateWorkouts/useDeleteTemplateWorkout.test.tsx
+++ b/frontend/src/hooks/templateWorkouts/useDeleteTemplateWorkout.test.tsx
@@ -1,0 +1,20 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http } from 'msw';
+import { server } from '../../mocks/server';
+import { useDeleteTemplateWorkout } from './useDeleteTemplateWorkout';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useDeleteTemplateWorkout', () => {
+  const url = 'http://localhost:3000/api/v1/template-workouts/1';
+  it('deletes workout', async () => {
+    server.use(http.delete(url, () => HttpResponse.json({})));
+    const { result } = renderHook(() => useDeleteTemplateWorkout(), { wrapper });
+    await act(() => result.current.mutateAsync({ id: '1' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/frontend/src/hooks/templateWorkouts/useUpdateWorkout.test.tsx
+++ b/frontend/src/hooks/templateWorkouts/useUpdateWorkout.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useUpdateTemplateWorkout } from './useUpdateWorkout';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useUpdateTemplateWorkout', () => {
+  const url = 'http://localhost:3000/api/v1/template-workouts/1';
+  it('updates workout', async () => {
+    const updated = { id: '1', name: 'new', createdAt: '', updatedAt: '' };
+    server.use(http.patch(url, () => HttpResponse.json(updated)));
+    const { result } = renderHook(() => useUpdateTemplateWorkout(), { wrapper });
+    await act(() => result.current.mutateAsync({ id: '1', dto: { name: 'new' } }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(updated);
+  });
+});

--- a/frontend/src/hooks/useAuth.test.tsx
+++ b/frontend/src/hooks/useAuth.test.tsx
@@ -1,0 +1,19 @@
+import { renderHook } from '@testing-library/react';
+import { AuthContext } from '../context/AuthContext';
+import { useAuth } from './useAuth';
+
+describe('useAuth', () => {
+  it('throws if no provider', () => {
+    const { result } = renderHook(() => useAuth());
+    expect(result.error).toEqual(Error('useAuth must be used within an AuthProvider'));
+  });
+
+  it('returns context value', () => {
+    const value = { token: 't', login: jest.fn(), logout: jest.fn(), isAuthenticated: true };
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+    );
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    expect(result.current).toBe(value);
+  });
+});

--- a/frontend/src/hooks/useDebounce.test.tsx
+++ b/frontend/src/hooks/useDebounce.test.tsx
@@ -1,0 +1,25 @@
+import { renderHook, act } from '@testing-library/react';
+import { useDebounce } from './useDebounce';
+
+jest.useFakeTimers();
+
+describe('useDebounce', () => {
+  it('debounces changing value', () => {
+    const { result, rerender } = renderHook(({ val }) => useDebounce(val, 500), {
+      initialProps: { val: 'a' },
+    });
+
+    expect(result.current).toBe('a');
+    rerender({ val: 'b' });
+
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(result.current).toBe('b');
+  });
+});

--- a/frontend/src/hooks/workoutExercises/useCreateExercise.test.tsx
+++ b/frontend/src/hooks/workoutExercises/useCreateExercise.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useCreateExercise } from './useCreateExercise';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useCreateExercise', () => {
+  const url = 'http://localhost:3000/api/v1/workouts/abc/exercises';
+  it('creates exercise', async () => {
+    const created = { workoutExerciseId: '1', exerciseId: 2, createdAt: '', updatedAt: '', workoutId: 'abc', position: 1, workoutSets: [] };
+    server.use(http.post(url, () => HttpResponse.json(created)));
+    const { result } = renderHook(() => useCreateExercise(), { wrapper });
+    await act(() => result.current.mutateAsync({ workoutId: 'abc', dto: { exerciseId: 2, position: 1 } }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(created);
+  });
+});

--- a/frontend/src/hooks/workoutExercises/useDeleteExercise.test.tsx
+++ b/frontend/src/hooks/workoutExercises/useDeleteExercise.test.tsx
@@ -1,0 +1,20 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http } from 'msw';
+import { server } from '../../mocks/server';
+import { useDeleteExercise } from './useDeleteExercise';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useDeleteExercise', () => {
+  const url = 'http://localhost:3000/api/v1/workouts/abc/exercises/1';
+  it('deletes exercise', async () => {
+    server.use(http.delete(url, () => HttpResponse.json({})));
+    const { result } = renderHook(() => useDeleteExercise(), { wrapper });
+    await act(() => result.current.mutateAsync({ workoutId: 'abc', id: '1' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/frontend/src/hooks/workoutExercises/useExercises.test.tsx
+++ b/frontend/src/hooks/workoutExercises/useExercises.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useWorkoutExercises } from './useExercises';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useWorkoutExercises', () => {
+  const url = 'http://localhost:3000/api/v1/workouts/abc/exercises';
+  it('returns exercises', async () => {
+    const data = [{ workoutExerciseId: '1', exerciseId: 2, createdAt: '', updatedAt: '', workoutId: 'abc', position: 1, workoutSets: [] }];
+    server.use(http.get(url, () => HttpResponse.json(data)));
+    const { result } = renderHook(() => useWorkoutExercises('abc'), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(data);
+  });
+});

--- a/frontend/src/hooks/workoutExercises/useUpdateExercise.test.tsx
+++ b/frontend/src/hooks/workoutExercises/useUpdateExercise.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useUpdateExercise } from './useUpdateExercise';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useUpdateExercise', () => {
+  const url = 'http://localhost:3000/api/v1/workouts/abc/exercises/1';
+  it('updates exercise', async () => {
+    const updated = { workoutExerciseId: '1', exerciseId: 2, createdAt: '', updatedAt: '', workoutId: 'abc', position: 2, workoutSets: [] };
+    server.use(http.patch(url, () => HttpResponse.json(updated)));
+    const { result } = renderHook(() => useUpdateExercise(), { wrapper });
+    await act(() => result.current.mutateAsync({ workoutId: 'abc', id: '1', dto: { position: 2 } }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(updated);
+  });
+});

--- a/frontend/src/hooks/workoutSets/useCreateSet.test.tsx
+++ b/frontend/src/hooks/workoutSets/useCreateSet.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useCreateSet } from './useCreateSet';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useCreateSet', () => {
+  const url = 'http://localhost:3000/api/v1/workouts/w/exercises/e/sets';
+  it('creates set', async () => {
+    const created = { id: 's1', createdAt: '', updatedAt: '', position: 1, reps: 1, weight: 1, completed: false };
+    server.use(http.post(url, () => HttpResponse.json(created)));
+    const { result } = renderHook(() => useCreateSet(), { wrapper });
+    await act(() => result.current.mutateAsync({ workoutId: 'w', exerciseId: 'e', dto: { reps: 1, weight: 1, position: 1 } }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(created);
+  });
+});

--- a/frontend/src/hooks/workoutSets/useDeleteSet.test.tsx
+++ b/frontend/src/hooks/workoutSets/useDeleteSet.test.tsx
@@ -1,0 +1,20 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http } from 'msw';
+import { server } from '../../mocks/server';
+import { useDeleteSet } from './useDeleteSet';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useDeleteSet', () => {
+  const url = 'http://localhost:3000/api/v1/workouts/w/exercises/e/sets/1';
+  it('deletes set', async () => {
+    server.use(http.delete(url, () => HttpResponse.json({})));
+    const { result } = renderHook(() => useDeleteSet(), { wrapper });
+    await act(() => result.current.mutateAsync({ setId: '1', workoutId: 'w', exerciseId: 'e' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/frontend/src/hooks/workoutSets/useSets.test.tsx
+++ b/frontend/src/hooks/workoutSets/useSets.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useWorkoutSets } from './useSets';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useWorkoutSets', () => {
+  const url = 'http://localhost:3000/api/v1/workouts/w/exercises/e/sets';
+  it('returns sets', async () => {
+    const data = [{ id: 's1', createdAt: '', updatedAt: '', position: 1, reps: 1, weight: 1, completed: false }];
+    server.use(http.get(url, () => HttpResponse.json(data)));
+    const { result } = renderHook(() => useWorkoutSets('w', 'e'), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(data);
+  });
+});

--- a/frontend/src/hooks/workoutSets/useUpdateSet.test.tsx
+++ b/frontend/src/hooks/workoutSets/useUpdateSet.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useUpdateSet } from './useUpdateSet';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useUpdateSet', () => {
+  const url = 'http://localhost:3000/api/v1/workouts/w/exercises/e/sets/1';
+  it('updates set', async () => {
+    const updated = { id: '1', createdAt: '', updatedAt: '', position: 1, reps: 2, weight: 2, completed: false };
+    server.use(http.patch(url, () => HttpResponse.json(updated)));
+    const { result } = renderHook(() => useUpdateSet(), { wrapper });
+    await act(() => result.current.mutateAsync({ setId: '1', workoutId: 'w', exerciseId: 'e', dto: { reps: 2 } }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(updated);
+  });
+});

--- a/frontend/src/hooks/workouts/useCreateFromTemplate.test.tsx
+++ b/frontend/src/hooks/workouts/useCreateFromTemplate.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useCreateWorkoutFromTemplate } from './useCreateFromTemplate';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useCreateWorkoutFromTemplate', () => {
+  const url = 'http://localhost:3000/api/v1/workouts/from-template/1';
+  it('creates workout', async () => {
+    const workout = { id: 'w1', createdAt: '', updatedAt: '', workoutTemplateId: '1', workoutExercises: [] };
+    server.use(http.post(url, () => HttpResponse.json(workout)));
+    const { result } = renderHook(() => useCreateWorkoutFromTemplate(), { wrapper });
+    await act(() => result.current.mutateAsync({ tid: '1' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(workout);
+  });
+});

--- a/frontend/src/hooks/workouts/useCreateWorkout.test.tsx
+++ b/frontend/src/hooks/workouts/useCreateWorkout.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useCreateWorkout } from './useCreateWorkout';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useCreateWorkout', () => {
+  const url = 'http://localhost:3000/api/v1/workouts';
+  it('creates workout', async () => {
+    const workout = { id: 'w1', createdAt: '', updatedAt: '', workoutTemplateId: null, workoutExercises: [] };
+    server.use(http.post(url, () => HttpResponse.json(workout)));
+    const { result } = renderHook(() => useCreateWorkout(), { wrapper });
+    await act(() => result.current.mutateAsync({ dto: { name: 'w' } }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(workout);
+  });
+});

--- a/frontend/src/hooks/workouts/useDeleteWorkout.test.tsx
+++ b/frontend/src/hooks/workouts/useDeleteWorkout.test.tsx
@@ -1,0 +1,20 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http } from 'msw';
+import { server } from '../../mocks/server';
+import { useDeleteWorkout } from './useDeleteWorkout';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useDeleteWorkout', () => {
+  const url = 'http://localhost:3000/api/v1/workouts/1';
+  it('deletes workout', async () => {
+    server.use(http.delete(url, () => HttpResponse.json({})));
+    const { result } = renderHook(() => useDeleteWorkout(), { wrapper });
+    await act(() => result.current.mutateAsync({ id: '1' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/frontend/src/hooks/workouts/useUpdateWorkout.test.tsx
+++ b/frontend/src/hooks/workouts/useUpdateWorkout.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { useUpdateWorkout } from './useUpdateWorkout';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useUpdateWorkout', () => {
+  const url = 'http://localhost:3000/api/v1/workouts/1';
+  it('updates workout', async () => {
+    const updated = { id: '1', createdAt: '', updatedAt: '', workoutTemplateId: null, workoutExercises: [] };
+    server.use(http.patch(url, () => HttpResponse.json(updated)));
+    const { result } = renderHook(() => useUpdateWorkout(), { wrapper });
+    await act(() => result.current.mutateAsync({ id: '1', dto: { name: 'w' } }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(updated);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for every hook in frontend

## Testing
- `npm test` *(fails: Prisma client not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_687bd748f8908323b29e78581e3f3ab7