### PR TITLE
Add unit tests for backend modules

### DIFF
--- a/backend/src/modules/v1/auth/auth.controller.spec.ts
+++ b/backend/src/modules/v1/auth/auth.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [{ provide: AuthService, useValue: {} }],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/modules/v1/auth/auth.service.spec.ts
+++ b/backend/src/modules/v1/auth/auth.service.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: UsersService, useValue: {} },
+        { provide: JwtService, useValue: {} },
+        { provide: PrismaService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/modules/v1/exercises-catalog/exercises.controller.spec.ts
+++ b/backend/src/modules/v1/exercises-catalog/exercises.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExercisesCatalogController } from './exercises.controller';
+import { ExercisesCatalogService } from './exercises.service';
+
+describe('ExercisesCatalogController', () => {
+  let controller: ExercisesCatalogController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ExercisesCatalogController],
+      providers: [{ provide: ExercisesCatalogService, useValue: {} }],
+    }).compile();
+
+    controller = module.get<ExercisesCatalogController>(ExercisesCatalogController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/modules/v1/exercises-catalog/exercises.service.spec.ts
+++ b/backend/src/modules/v1/exercises-catalog/exercises.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExercisesCatalogService } from './exercises.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+describe('ExercisesCatalogService', () => {
+  let service: ExercisesCatalogService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ExercisesCatalogService, { provide: PrismaService, useValue: {} }],
+    }).compile();
+
+    service = module.get<ExercisesCatalogService>(ExercisesCatalogService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/modules/v1/template-workouts/template-workouts.controller.spec.ts
+++ b/backend/src/modules/v1/template-workouts/template-workouts.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TemplateWorkoutsController } from './template-workouts.controller';
+import { TemplateWorkoutsService } from './template-workouts.service';
+
+describe('TemplateWorkoutsController', () => {
+  let controller: TemplateWorkoutsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TemplateWorkoutsController],
+      providers: [{ provide: TemplateWorkoutsService, useValue: {} }],
+    }).compile();
+
+    controller = module.get<TemplateWorkoutsController>(TemplateWorkoutsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/modules/v1/template-workouts/template-workouts.service.spec.ts
+++ b/backend/src/modules/v1/template-workouts/template-workouts.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TemplateWorkoutsService } from './template-workouts.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+describe('TemplateWorkoutsService', () => {
+  let service: TemplateWorkoutsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TemplateWorkoutsService, { provide: PrismaService, useValue: {} }],
+    }).compile();
+
+    service = module.get<TemplateWorkoutsService>(TemplateWorkoutsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/modules/v1/users/users.controller.spec.ts
+++ b/backend/src/modules/v1/users/users.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+
+describe('UsersController', () => {
+  let controller: UsersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [{ provide: UsersService, useValue: {} }],
+    }).compile();
+
+    controller = module.get<UsersController>(UsersController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/modules/v1/users/users.service.spec.ts
+++ b/backend/src/modules/v1/users/users.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersService } from './users.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UsersService, { provide: PrismaService, useValue: {} }],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/modules/v1/workouts/workouts.controller.spec.ts
+++ b/backend/src/modules/v1/workouts/workouts.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WorkoutsController } from './workouts.controller';
+import { WorkoutsService } from './workouts.service';
+
+describe('WorkoutsController', () => {
+  let controller: WorkoutsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WorkoutsController],
+      providers: [{ provide: WorkoutsService, useValue: {} }],
+    }).compile();
+
+    controller = module.get<WorkoutsController>(WorkoutsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/modules/v1/workouts/workouts.service.spec.ts
+++ b/backend/src/modules/v1/workouts/workouts.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WorkoutsService } from './workouts.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+describe('WorkoutsService', () => {
+  let service: WorkoutsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WorkoutsService, { provide: PrismaService, useValue: {} }],
+    }).compile();
+
+    service = module.get<WorkoutsService>(WorkoutsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add jest specs for all v1 controllers and services
- ensure tests run successfully

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bf0dc54cc8323834c50acb24e4408